### PR TITLE
docs: add installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,43 @@ La misión de Salvida es facilitar el transporte accesible y el acompañamiento 
 
 **Styling:** [HeroUI](https://www.heroui.com/) / [ShadCN](https://ui.shadcn.com/) 💎
 
+## Instalación
+
+### Requisitos previos
+- [Node.js](https://nodejs.org/) 20.x y npm
+- [Python](https://www.python.org/) 3.12
+- [PostgreSQL](https://www.postgresql.org/) (opcional para entorno local)
+
+### Dependencias
+#### Frontend
+```bash
+cd frontend
+npm install
+```
+
+#### Backend
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Uso
+
+### Frontend
+```bash
+cd frontend
+npm run dev
+```
+
+### Backend
+```bash
+cd backend
+source .venv/bin/activate
+uvicorn main:app --reload
+```
+
 ## Pages
 
 - **Landing/Home**  


### PR DESCRIPTION
## Summary
- document installation prerequisites and dependency setup for frontend and backend
- add usage guide to run frontend and backend in development mode

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0501775e483239091735a819dcb39