### PR TITLE
Fix JSON examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ uvicorn main:app --reload
   "phone": "string",
   "email": "string",
   "avatar": "string",
-  "role": "user || admin"
-  "bookings": {
-     {
+  "role": "user || admin",
+  "bookings": [
+    {
       "id": "uuid",
       "date": "timestamp",
       "prm": "uuid",
@@ -96,9 +96,9 @@ uvicorn main:app --reload
       "type": "singleService || voucher",
       "status": "requested || approved || canceled || done",
       "pickupAddress": "string",
-      "destinationAddress": "string",
+      "destinationAddress": "string"
     }
-  }
+  ]
 }
 ```
 
@@ -118,23 +118,23 @@ uvicorn main:app --reload
   "countryCode": "string",
   "phone": "string",
   "emergenciesPhoneNumbers": ["string"],
-  "pickupAddresses": {
+  "pickupAddresses": [
     {
       "id": "uuid",
       "address": "string",
       "location": "string",
       "contactPerson": "string || null"
     }
-  },
-  "destinationAddresses": {
+  ],
+  "destinationAddresses": [
     {
       "id": "uuid",
       "address": "string",
       "location": "string",
       "alias": "string"
     }
-  },
-  "bookings": {
+  ],
+  "bookings": [
     {
       "id": "uuid",
       "date": "timestamp",
@@ -143,9 +143,9 @@ uvicorn main:app --reload
       "type": "singleService || voucher",
       "status": "requested || approved || canceled || done",
       "pickupAddress": "string",
-      "destinationAdress": "string"
+      "destinationAddress": "string"
     }
-  }
+  ]
 }
 ```
 


### PR DESCRIPTION
## Summary
- fix JSON examples to use arrays instead of nested objects
- correct destinationAddress typo
- ensure example snippets are valid JSON

## Testing
- `sed -n '77,102p' README.md | jq .`
- `sed -n '110,149p' README.md | jq .`
- `sed -n '155,164p' README.md | jq .`


------
https://chatgpt.com/codex/tasks/task_e_68c0512d0c3883238678d25b6f51d88c