### PR TITLE
feat: add configurable theme system

### DIFF
--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -1,0 +1,13 @@
+---
+import '../styles/theme.css';
+---
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>{Astro.props.title || 'Salvida'}</title>
+    <script type="module" src="../theme/client.js"></script>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -1,12 +1,7 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Sobre Salvida</title>
-  </head>
-  <body>
-    <h2>Sobre nosotros</h2>
-    <p>Misión, visión y equipo de Salvida.</p>
-  </body>
-</html>
+<BaseLayout title="Sobre Salvida">
+  <h2>Sobre nosotros</h2>
+  <p>Misión, visión y equipo de Salvida.</p>
+</BaseLayout>

--- a/frontend/src/pages/admin.astro
+++ b/frontend/src/pages/admin.astro
@@ -1,12 +1,7 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Panel Admin</title>
-  </head>
-  <body>
-    <h2>Panel de administración</h2>
-    <p>Administrar usuarios, PRM y reservas.</p>
-  </body>
-</html>
+<BaseLayout title="Panel Admin">
+  <h2>Panel de administración</h2>
+  <p>Administrar usuarios, PRM y reservas.</p>
+</BaseLayout>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,13 +1,7 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Salvida</title>
-  </head>
-  <body>
-    <h1>Bienvenido a Salvida</h1>
-    <p>Servicio de transporte accesible.</p>
-  </body>
-</html>
+<BaseLayout title="Salvida">
+  <h1>Bienvenido a Salvida</h1>
+  <p>Servicio de transporte accesible.</p>
+</BaseLayout>

--- a/frontend/src/pages/prm.astro
+++ b/frontend/src/pages/prm.astro
@@ -1,12 +1,7 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Perfil PRM</title>
-  </head>
-  <body>
-    <h2>Perfil de la persona con movilidad reducida</h2>
-    <p>Contenido pendiente.</p>
-  </body>
-</html>
+<BaseLayout title="Perfil PRM">
+  <h2>Perfil de la persona con movilidad reducida</h2>
+  <p>Contenido pendiente.</p>
+</BaseLayout>

--- a/frontend/src/pages/profile.astro
+++ b/frontend/src/pages/profile.astro
@@ -1,13 +1,7 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 import UserProfile from '../components/UserProfile.jsx';
 ---
-
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Perfil</title>
-  </head>
-  <body>
-    <UserProfile client:load />
-  </body>
-</html>
+<BaseLayout title="Perfil">
+  <UserProfile client:load />
+</BaseLayout>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,19 @@
+:root {
+  --color-primary: #1E88E5;
+  --color-secondary: #F4511E;
+  --color-accent: #8E24AA;
+  --color-neutral: #424242;
+  --color-background: #FFFFFF;
+  --color-foreground: #212121;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: system-ui, sans-serif;
+  margin: 0;
+}
+
+a {
+  color: var(--color-primary);
+}

--- a/frontend/src/theme/client.js
+++ b/frontend/src/theme/client.js
@@ -1,0 +1,3 @@
+import { applyTheme, themes } from './index.js';
+
+applyTheme(themes.salvida);

--- a/frontend/src/theme/index.js
+++ b/frontend/src/theme/index.js
@@ -1,0 +1,19 @@
+export const themes = {
+  salvida: {
+    colors: {
+      primary: '#1E88E5',
+      secondary: '#F4511E',
+      accent: '#8E24AA',
+      neutral: '#424242',
+      background: '#FFFFFF',
+      foreground: '#212121'
+    }
+  }
+};
+
+export function applyTheme(theme = themes.salvida) {
+  const root = document.documentElement;
+  Object.entries(theme.colors).forEach(([token, value]) => {
+    root.style.setProperty(`--color-${token}`, value);
+  });
+}


### PR DESCRIPTION
## Summary
- add central theme module with Salvida color palette
- apply theme via reusable BaseLayout and CSS variables
- update pages to use new layout for consistent styling

## Testing
- `npm test` *(fails: astro: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@astrojs%2freact)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ac24fad88323a147504bc4f89a3e