### PR TITLE
feat: agrega navegación entre páginas

### DIFF
--- a/frontend/src/components/NavBar.astro
+++ b/frontend/src/components/NavBar.astro
@@ -1,0 +1,33 @@
+---
+const links = [
+  { href: '/', text: 'Inicio' },
+  { href: '/about', text: 'Sobre nosotros' },
+  { href: '/profile', text: 'Perfil' },
+  { href: '/prm', text: 'PRM' },
+  { href: '/admin', text: 'Admin' }
+];
+---
+<nav>
+  <ul>
+    {links.map(link => (
+      <li><a href={link.href}>{link.text}</a></li>
+    ))}
+  </ul>
+</nav>
+<style>
+  nav {
+    background: var(--color-primary);
+    padding: 1rem;
+  }
+  ul {
+    display: flex;
+    list-style: none;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+  }
+  a {
+    color: white;
+    text-decoration: none;
+  }
+</style>

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/theme.css';
+import NavBar from '../components/NavBar.astro';
 ---
 <html lang="es">
   <head>
@@ -8,6 +9,7 @@ import '../styles/theme.css';
     <script type="module" src="../theme/client.js"></script>
   </head>
   <body>
+    <NavBar />
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- añade componente `NavBar` con enlaces a Inicio, Sobre, Perfil, PRM y Admin
- incluye `NavBar` en el `BaseLayout` para mostrar navegación en todas las páginas

## Testing
- `npm test` *(falla: sh: 1: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1db1bfe748323a281d731d43c3958