### PR TITLE
feat: expand pages with content and style

### DIFF
--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -10,6 +10,8 @@ import NavBar from '../components/NavBar.astro';
   </head>
   <body>
     <NavBar />
-    <slot />
+    <main class="container">
+      <slot />
+    </main>
   </body>
 </html>

--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -2,6 +2,30 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Sobre Salvida">
-  <h2>Sobre nosotros</h2>
-  <p>Misión, visión y equipo de Salvida.</p>
+  <section>
+    <h2>Nuestra misión</h2>
+    <p>Facilitar el transporte accesible y el acompañamiento seguro para que cada persona mantenga su autonomía.</p>
+  </section>
+
+  <section>
+    <h2>Visión</h2>
+    <p>Construir una comunidad inclusiva en la que las barreras de movilidad desaparezcan mediante tecnología y apoyo humano.</p>
+  </section>
+
+  <section>
+    <h2>El equipo</h2>
+    <p>Salvida está formado por profesionales comprometidos con la accesibilidad:</p>
+    <ul>
+      <li>Ana – Fundadora y coordinadora.</li>
+      <li>Carlos – Responsable de operaciones.</li>
+      <li>Laura – Especialista en atención al usuario.</li>
+    </ul>
+  </section>
+
+  <style>
+    ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+  </style>
 </BaseLayout>

--- a/frontend/src/pages/admin.astro
+++ b/frontend/src/pages/admin.astro
@@ -2,6 +2,18 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Panel Admin">
-  <h2>Panel de administración</h2>
-  <p>Administrar usuarios, PRM y reservas.</p>
+  <section>
+    <h2>Usuarios</h2>
+    <p>Gestiona cuentas registradas y roles.</p>
+  </section>
+
+  <section>
+    <h2>Personas PRM</h2>
+    <p>Revisa perfiles de personas con movilidad reducida.</p>
+  </section>
+
+  <section>
+    <h2>Reservas</h2>
+    <p>Controla solicitudes y estado de los servicios.</p>
+  </section>
 </BaseLayout>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -2,6 +2,45 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Salvida">
-  <h1>Bienvenido a Salvida</h1>
-  <p>Servicio de transporte accesible.</p>
+  <section class="hero">
+    <h1>Bienvenido a Salvida</h1>
+    <p>Servicio de transporte accesible y acompañamiento para personas con movilidad reducida.</p>
+  </section>
+
+  <section class="features">
+    <h2>¿Qué ofrecemos?</h2>
+    <ul>
+      <li>Transporte seguro y adaptado a cada necesidad.</li>
+      <li>Acompañamiento por profesionales cualificados.</li>
+      <li>Gestión sencilla de reservas y perfiles.</li>
+    </ul>
+  </section>
+
+  <section class="cta">
+    <h2>Únete a la comunidad</h2>
+    <p>
+      <a href="/profile" class="btn">Crea tu perfil</a>
+      <a href="/about" class="btn btn-secondary">Conócenos</a>
+    </p>
+  </section>
+
+  <style>
+    .hero {
+      text-align: center;
+      padding: 4rem 1rem;
+      background: var(--color-primary);
+      color: #fff;
+      border-radius: 8px;
+    }
+    .features ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .cta {
+      text-align: center;
+    }
+    .cta .btn {
+      margin-right: 0.5rem;
+    }
+  </style>
 </BaseLayout>

--- a/frontend/src/pages/prm.astro
+++ b/frontend/src/pages/prm.astro
@@ -2,6 +2,32 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Perfil PRM">
-  <h2>Perfil de la persona con movilidad reducida</h2>
-  <p>Contenido pendiente.</p>
+  <section>
+    <h2>Datos personales</h2>
+    <p>Información básica de la persona beneficiaria del servicio.</p>
+  </section>
+
+  <section>
+    <h2>Direcciones frecuentes</h2>
+    <ul>
+      <li>Casa</li>
+      <li>Centro médico</li>
+      <li>Lugar de trabajo</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Contactos de emergencia</h2>
+    <ul>
+      <li>María – 666 123 456</li>
+      <li>Juan – 666 654 321</li>
+    </ul>
+  </section>
+
+  <style>
+    ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+  </style>
 </BaseLayout>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -17,3 +17,33 @@ body {
 a {
   color: var(--color-primary);
 }
+
+main.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+h1,
+h2,
+h3 {
+  color: var(--color-primary);
+  margin-top: 0;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.btn-secondary {
+  background: var(--color-secondary);
+}


### PR DESCRIPTION
## Summary
- flesh out landing, about, admin and PRM pages with structured content
- wrap layout slot in a centered main container and add global button styles
- add global theme styles for headings, sections and containers

## Testing
- `npm test` *(fails: The `@astrojs/check` and `typescript` packages are required for this command to work)*
- `npm install --no-save @astrojs/check typescript` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@astrojs%2fcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dd34f4208323906988c8416edbaf