### PR TITLE
Add tests for PRM and booking endpoints

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./salvida.db")
 
 connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
-engine = create_engine(DATABASE_URL, **connect_args)
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/backend/tests/test_prms_bookings.py
+++ b/backend/tests/test_prms_bookings.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_list_prms():
+    response = client.get("/prms")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert data and data[0]["id"] == "prm1"
+
+
+def test_get_prm():
+    response = client.get("/prms/prm1")
+    assert response.status_code == 200
+    assert response.json()["id"] == "prm1"
+
+
+def test_get_prm_not_found():
+    response = client.get("/prms/nonexistent")
+    assert response.status_code == 404
+
+
+def test_list_bookings():
+    response = client.get("/bookings")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert data and data[0]["id"] == "booking1"
+
+
+def test_get_booking():
+    response = client.get("/bookings/booking1")
+    assert response.status_code == 200
+    assert response.json()["id"] == "booking1"
+
+
+def test_get_booking_not_found():
+    response = client.get("/bookings/nonexistent")
+    assert response.status_code == 404
+


### PR DESCRIPTION
## Summary
- add database connect_args to sqlite engine
- test list and detail endpoints for PRMs and bookings including 404 cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c2f1415aa88323a1f79fed4828d0d7