### PR TITLE
Add Vitest testing and basic component tests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,10 @@
         "nanostores": "^0.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "devDependencies": {
+        "@testing-library/react": "^14.2.1",
+        "vitest": "^1.6.0"
       }
     },
     "node_modules/@astrojs/compiler": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "astro check"
+    "test": "vitest"
   },
   "dependencies": {
     "@astrojs/react": "^4.3.1",
@@ -17,5 +17,9 @@
     "nanostores": "^0.9.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.2.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/tests/BookingList.test.jsx
+++ b/frontend/tests/BookingList.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BookingList from '../src/components/BookingList.jsx';
+
+describe('BookingList', () => {
+  it('muestra reservas después de cargar', async () => {
+    const mockBookings = [
+      { id: 1, date: '2024-01-01', status: 'confirmada' }
+    ];
+
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockBookings
+    });
+
+    render(<BookingList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2024-01-01 - confirmada')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Reservas')).toBeTruthy();
+    global.fetch.mockRestore();
+  });
+});

--- a/frontend/tests/UserProfile.test.jsx
+++ b/frontend/tests/UserProfile.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import UserProfile from '../src/components/UserProfile.jsx';
+import { userName } from '../src/stores/user.js';
+
+describe('UserProfile', () => {
+  it('muestra información del usuario', async () => {
+    userName.set('Carlos');
+
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'Carlos', email: 'carlos@example.com' })
+    });
+
+    render(<UserProfile userId={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Nombre: Carlos')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Perfil de Carlos')).toBeTruthy();
+    expect(screen.getByText('Email: carlos@example.com')).toBeTruthy();
+    global.fetch.mockRestore();
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom environment
- add basic BookingList and UserProfile component tests
- replace `npm test` script with Vitest and add dev dependencies

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f6e2c9b083238039f6907c6822b5