### PR TITLE
Add env example files and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,23 @@ uvicorn main:app --reload
 
 #### Variables de entorno
 
-El backend usa autenticación basada en JWT. Antes de iniciar el servicio, define las siguientes variables de entorno:
+Antes de iniciar los servicios, copia los archivos de ejemplo y ajusta los valores según tu entorno local:
 
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
+**Backend** (`backend/.env`)
+
+- `DATABASE_URL`: URL de conexión a la base de datos.
 - `SECRET_KEY`: clave secreta para firmar los tokens.
 - `ALGORITHM`: algoritmo de firma (por defecto `HS256`).
 - `ACCESS_TOKEN_EXPIRE_MINUTES`: tiempo de expiración del token en minutos.
+
+**Frontend** (`frontend/.env`)
+
+- `VITE_API_URL`: URL base del backend.
 
 ## Pages
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/salvida
+SECRET_KEY=super-secret-key
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add `.env.example` for backend and frontend
- document copying `.env.example` to `.env` in README

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx; 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org/@testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f82eda1c8323970823a0324c154c